### PR TITLE
Channel tags: integration/prod (align with shared workflow)

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -39,9 +39,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.OCI_REPO }}/${{ env.PROJECT }}
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            # prerelease tags (v1.2.3-rc1) must not move the prod channel
+            type=raw,value=prod,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
+            type=raw,value=integration,enable={{is_default_branch}}
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Brings supersplat's inline build workflow onto the org channel contract (myx-ad/workflows#9): main pushes publish :integration, v* release tags publish <semver> + :prod (prerelease tags never move prod), and :latest is no longer published — QA/consumers pin channel tags now. Single final-state PR: nothing consumes supersplat:latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)